### PR TITLE
Modified

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -14,7 +14,7 @@ class CommentsController < ApplicationController
   end
 
   def destroy
-    @comment = Comment.find_by(id: params[:id], tweet_id: params[:tweet_id])
+    @comment = Comment.find_by(id: params[:id], tweet_id: params[:id])
     @comment.destroy
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -14,7 +14,7 @@ class CommentsController < ApplicationController
   end
 
   def destroy
-    @comment = Comment.find_by(id: params[:id], tweet_id: params[:id])
+    @comment = Comment.find_by(id: params[:id])
     @comment.destroy
   end
 

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -59,7 +59,7 @@ class TweetsController < ApplicationController
   end
 
   def tweet_params
-    params.require(:tweet).permit(:title, :body, :image, { genre_ids: [] })
     # genre_ids: [] チェックボックスによって複数渡される場合があるのため配列形式
+    params.require(:tweet).permit(:title, :body, :image, { genre_ids: [] })
   end
 end


### PR DESCRIPTION
コメントの削除アクションでの
@comment = Comment.find_by(id: params[:id], tweet_id: params[:tweet_id])
tweet_id: params[:tweet_id]を不要なので削除しました。